### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/com.github.edenalencar.identifications.json
+++ b/com.github.edenalencar.identifications.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.edenalencar.identifications",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "identifications",
     "finish-args": [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.